### PR TITLE
Vberenz/mkdocs

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material mkdocstrings[python] mkdocs-jupyter
+      - run: pip install mkdocs mkdocs-material mkdocstrings[python]
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -1,0 +1,16 @@
+name: mkdocs
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material mkdocstrings[python] mkdocs-jupyter
+      - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,12 @@ __pycache__/
 # directories
 wandb/
 checkpoints/
+
+# emacs
+*~
+
+# mkdocs
+site
+
+# virtual env
+venv

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![license: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![arXiv](https://img.shields.io/badge/arXiv-2305.17225-00ff00.svg)](https://arxiv.org/abs/2305.17225)
+[![documentation](https://github.com/akekic/causal-component-analysis/actions/workflows/mkdocs.yaml/badge.svg)](https://akekic.github.io/causal-component-analysis/)
 
 
-
-![Cauca](cauca.png)
+![Cauca](https://raw.githubusercontent.com/akekic/causal-component-analysis/master/cauca.png)
 ## Overview
 _Causal Component Analysis_ is a project that bridges the gap between Independent Component Analysis (ICA) and Causal Representation Learning (CRL).
 This project includes implementations and experiments related to the papers:
@@ -21,7 +21,7 @@ This project includes implementations and experiments related to the papers:
     [Nonparametric Identifiability of Causal Representations from Unknown Interventions](https://openreview.net/forum?id=V87gZeSOL4).
     In Proceedings of the Thirty-seventh Conference on Neural Information Processing Systems.
     
-    The corrsponding experiments are in the [experiments/nonparam_ident](experiments/nonparam_ident/README.md) folder.
+    The corrsponding experiments are in the [experiments/nonparam_ident](https://raw.githubusercontent.com/akekic/causal-component-analysis/master/experiments/nonparam_ident/README.md) folder.
 ## Installation
 Clone the repository
 ```bash
@@ -36,7 +36,7 @@ pip install -e .
 
 
 ## License
-This project is licensed under the [MIT license](https://opensource.org/licenses/MIT). See the [LICENSE](LICENSE) file for details.
+This project is licensed under the [MIT license](https://opensource.org/licenses/MIT). See the [LICENSE](https://raw.githubusercontent.com/akekic/causal-component-analysis/master/LICENSE) file for details.
 
 ## Citation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,4 @@
+# API references
+
+::: data_generator
+::: model

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,16 @@
+site_name: Causal Component Analysis
+site_url: https://github.com/akekic/causal-component-analysis/
+
+
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_submodules: true
+
+nav:
+  - About: index.md
+  - API: references.md

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+mkdocs
+mkdocstrings[python]
+mkdocs-material

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 from setuptools import setup, find_packages
 
+
 def parse_requirements(filename):
     """load requirements from a pip requirements file"""
     lineiter = (line.strip() for line in open(filename))
     return [line for line in lineiter if line and not line.startswith("#")]
+
 
 setup(
     name="causal-component-analysis",
@@ -17,6 +19,7 @@ setup(
     install_requires=parse_requirements("./requirements.txt"),
     extras_require={
         "plots": parse_requirements("./requirements-plots.txt"),
+        "dev": parse_requirements("./requirements-dev.txt"),
     },
     license="MIT",
 )


### PR DESCRIPTION
Setup mkdocs for the repository.
The documentation is the content of README.md file rendered in HTML + the API documentation generated from the docstrings.

## run locally
After installing the dev requirements:

```
mkdocs server
```
will start a local server to see the documentation.

The document can then be built:
```
mkdocs build
```
will create a site folder in the current folder with the html content.

To push online (to the gh-pages branch of the repo, which will make the content available on https://akekic.github.io/causal-component-analysis/ : 

```
mkdocs gh-deploy –force 
```

## On github server

The github workflow that build the documentation and pushes it to the gh-pages branch will run everytime the master branch is updated.

The workflow can also be run by visiting the "actions" tab of the repository.  





